### PR TITLE
fix: 프로젝트 설정 변경

### DIFF
--- a/demo2/.gitignore
+++ b/demo2/.gitignore
@@ -36,3 +36,7 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+## intelij code style
+/.idea/codeStyles/codeStyleConfig.xml
+/.idea/git_toolbox_blame.xml

--- a/demo2/.idea/misc.xml
+++ b/demo2/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="JavaSE-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/demo2/.idea/vcs.xml
+++ b/demo2/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/demo2/pom.xml
+++ b/demo2/pom.xml
@@ -12,29 +12,27 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
-        <junit.version>5.11.0</junit.version>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.1.0</version>
+            <version>6.0.0</version> <!-- Jakarta EE 10 -->
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>10.1.20</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.36</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- 인텔리제이 코드스타일, 플러그인 xml  -> .gitignore에 추가
     - 개발자마다 코드 포맷이 달라서 추가했습니다
- 자바 버전 17로 적용되어 있어서 11 버전으로 통일하면 좋을 것 같습니다
- pom.xml 에 자바 버전이랑 롬복, 기타 의존성 추가 했습니다
- 사용버전 정리
  - java 11
  - tomcat 10.1.x
  - servlet jakarata.servlet-api:6.0.0
  - maven 4.0.0